### PR TITLE
Change order of slicing when using _subdiagrams in Parallel calls, minor style changes

### DIFF
--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -75,7 +75,7 @@ def landscapes(diagrams, sampling, n_layers):
 
 
 def _heat(image, sampled_diag, sigma):
-    _sample_image(image, sampled_diag)  # modifies `heat` inplace
+    _sample_image(image, sampled_diag)
     image[:] = gaussian_filter(image, sigma, mode="reflect")
 
 

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -29,6 +29,7 @@ def _sort(Xs):
 
 
 def _sample_image(image, sampled_diag):
+    # NOTE: Modifies `image` in-place
     unique, counts = np.unique(sampled_diag, axis=0, return_counts=True)
     unique = tuple(tuple(row) for row in unique.astype(np.int).T)
     image[unique] = counts

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -113,7 +113,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
 
         with np.errstate(divide='ignore', invalid='ignore'):
             Xt = Parallel(n_jobs=self.n_jobs)(
-                delayed(self._persistence_entropy)(_subdiagrams(X, [dim])[s])
+                delayed(self._persistence_entropy)(_subdiagrams(X[s], [dim]))
                 for dim in self.homology_dimensions_
                 for s in gen_even_slices(
                     X.shape[0], effective_n_jobs(self.n_jobs))

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -115,8 +115,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
             Xt = Parallel(n_jobs=self.n_jobs)(
                 delayed(self._persistence_entropy)(_subdiagrams(X[s], [dim]))
                 for dim in self.homology_dimensions_
-                for s in gen_even_slices(
-                    X.shape[0], effective_n_jobs(self.n_jobs))
+                for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))
             )
         Xt = np.concatenate(Xt).reshape(self._n_dimensions, X.shape[0]).T
         return Xt

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -142,13 +142,12 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
         X = check_diagrams(X)
 
         Xt = Parallel(n_jobs=self.n_jobs)(delayed(betti_curves)(
-                _subdiagrams(X, [dim], remove_dim=True)[s],
+                _subdiagrams(X[s], [dim], remove_dim=True),
                 self._samplings[dim])
             for dim in self.homology_dimensions_
-            for s in gen_even_slices(X.shape[0],
-                                     effective_n_jobs(self.n_jobs)))
+            for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs)))
         Xt = np.concatenate(Xt).\
-            reshape(self._n_dimensions, X.shape[0], -1).\
+            reshape(self._n_dimensions, len(X), -1).\
             transpose((1, 0, 2))
         return Xt
 
@@ -354,14 +353,13 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
         X = check_diagrams(X)
 
         Xt = Parallel(n_jobs=self.n_jobs)(delayed(landscapes)(
-                _subdiagrams(X, [dim], remove_dim=True)[s],
+                _subdiagrams(X[s], [dim], remove_dim=True),
                 self._samplings[dim],
                 self.n_layers)
             for dim in self.homology_dimensions_
-            for s in gen_even_slices(X.shape[0],
-                                     effective_n_jobs(self.n_jobs)))
-        Xt = np.concatenate(Xt).reshape(self._n_dimensions, X.shape[0],
-                                        self.n_layers, self.n_bins).\
+            for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs)))
+        Xt = np.concatenate(Xt).\
+            reshape(self._n_dimensions, len(X), self.n_layers, self.n_bins).\
             transpose((1, 0, 2, 3))
         return Xt
 
@@ -591,10 +589,9 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
             heats)(_subdiagrams(X[s], [dim], remove_dim=True),
                    self._samplings[dim], self._step_size[dim], self.sigma)
             for dim in self.homology_dimensions_
-            for s in gen_even_slices(X.shape[0],
-                                     effective_n_jobs(self.n_jobs)))
+            for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs)))
         Xt = np.concatenate(Xt).\
-            reshape(self._n_dimensions, X.shape[0], self.n_bins, self.n_bins).\
+            reshape(self._n_dimensions, len(X), self.n_bins, self.n_bins).\
             transpose((1, 0, 2, 3))
         return Xt
 
@@ -801,11 +798,10 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
                 self.sigma
             )
             for dim in self.homology_dimensions_
-            for s in gen_even_slices(X.shape[0],
-                                     effective_n_jobs(self.n_jobs))
+            for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))
         )
         Xt = np.concatenate(Xt).\
-            reshape(self._n_dimensions, X.shape[0], self.n_bins, self.n_bins).\
+            reshape(self._n_dimensions, len(X), self.n_bins, self.n_bins).\
             transpose((1, 0, 2, 3))
         return Xt
 
@@ -979,11 +975,10 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
               (delayed(silhouettes)(_subdiagrams(X[s], [dim], remove_dim=True),
                                     self._samplings[dim], power=self.power)
               for dim in self.homology_dimensions_
-              for s in gen_even_slices(X.shape[0],
-                                       effective_n_jobs(self.n_jobs))))
+              for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))))
 
-        Xt = np.concatenate(Xt). \
-            reshape(self._n_dimensions, X.shape[0], -1). \
+        Xt = np.concatenate(Xt).\
+            reshape(self._n_dimensions, len(X), -1).\
             transpose((1, 0, 2))
         return Xt
 

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -588,13 +588,13 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
         X = check_diagrams(X, copy=True)
 
         Xt = Parallel(n_jobs=self.n_jobs, mmap_mode='c')(delayed(
-            heats)(_subdiagrams(X, [dim], remove_dim=True)[s],
+            heats)(_subdiagrams(X[s], [dim], remove_dim=True),
                    self._samplings[dim], self._step_size[dim], self.sigma)
             for dim in self.homology_dimensions_
             for s in gen_even_slices(X.shape[0],
                                      effective_n_jobs(self.n_jobs)))
-        Xt = np.concatenate(Xt).reshape(self._n_dimensions, X.shape[0],
-                                        self.n_bins, self.n_bins).\
+        Xt = np.concatenate(Xt).\
+            reshape(self._n_dimensions, X.shape[0], self.n_bins, self.n_bins).\
             transpose((1, 0, 2, 3))
         return Xt
 
@@ -793,18 +793,19 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         X = check_diagrams(X, copy=True)
 
         Xt = Parallel(n_jobs=self.n_jobs, mmap_mode='c')(
-            delayed(persistence_images)(_subdiagrams(X, [dim],
-                                                     remove_dim=True)[s],
-                                        self._samplings[dim],
-                                        self._step_size[dim],
-                                        self.weights_[dim],
-                                        self.sigma)
+            delayed(persistence_images)(
+                _subdiagrams(X[s], [dim], remove_dim=True),
+                self._samplings[dim],
+                self._step_size[dim],
+                self.weights_[dim],
+                self.sigma
+            )
             for dim in self.homology_dimensions_
             for s in gen_even_slices(X.shape[0],
                                      effective_n_jobs(self.n_jobs))
         )
-        Xt = np.concatenate(Xt).reshape(self._n_dimensions, X.shape[0],
-                                        self.n_bins, self.n_bins).\
+        Xt = np.concatenate(Xt).\
+            reshape(self._n_dimensions, X.shape[0], self.n_bins, self.n_bins).\
             transpose((1, 0, 2, 3))
         return Xt
 
@@ -975,7 +976,7 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         X = check_diagrams(X)
 
         Xt = (Parallel(n_jobs=self.n_jobs)
-              (delayed(silhouettes)(_subdiagrams(X, [dim], remove_dim=True)[s],
+              (delayed(silhouettes)(_subdiagrams(X[s], [dim], remove_dim=True),
                                     self._samplings[dim], power=self.power)
               for dim in self.homology_dimensions_
               for s in gen_even_slices(X.shape[0],

--- a/gtda/plotting/persistence_diagrams.py
+++ b/gtda/plotting/persistence_diagrams.py
@@ -76,8 +76,7 @@ def plot_diagram(diagram, homology_dimensions=None, **input_layout):
 
     for dim in homology_dimensions:
         name = f'H{int(dim)}' if dim != np.inf else 'Any homology dimension'
-        subdiagram = _subdiagrams(np.asarray([diagram]), [dim],
-                                  remove_dim=True)[0]
+        subdiagram = diagram[diagram[:, 2] == dim]
         diff = (subdiagram[:, 1] != subdiagram[:, 0])
         subdiagram = subdiagram[diff]
         fig.add_trace(gobj.Scatter(x=subdiagram[:, 0], y=subdiagram[:, 1],


### PR DESCRIPTION
**Reference issues/PRs**
https://github.com/giotto-ai/giotto-tda/pull/428

**Description**
When reviewing your PR, I noticed that we are being inefficient with our calls to `_subdiagrams` in the context of calls to `Parallel` when slices are used.  It is slightly more efficient to first slice `X`, and then call `_subdiagrams` on each slice to extract the subdiagrams (`_subdiagrams` always copies data over).  Would you be happy to sneak this into https://github.com/giotto-ai/giotto-tda/pull/428?  I also made a couple of other tiny changes (use `len` instead of `.shape[0]`, a small improvement in `plot_diagram`) in passing.